### PR TITLE
⚙️Setting : 컬러 자동완성 및 우선순위

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,23 @@
+{
+  "tailwindCSS.experimental.classRegex": [
+    // @utility 뒤에 오는 클래스 이름을 자동완성에 포함
+    ["@utility\\s+([a-zA-Z0-9-_]+)", "([a-zA-Z0-9-_]+)"]
+  ],
+  // Tailwind 자동완성 동장할 매핑
+  "tailwindCSS.includeLanguages": {
+    "javascript": "javascript",
+    "typescript": "typescript",
+    "typescriptreact": "html",
+    "javascriptreact": "html",
+    "css": "css",
+    "scss": "css"
+  },
+
+  // 문자열 안에서도 VSCode 자동완성 제안 표시
+  "editor.quickSuggestions": {
+    "strings": true
+  },
+  // 자동완성 추천 항목을 선택하기 전에 미리보기 표시
+  "tailwindCSS.emmetCompletions": true,
+  "editor.suggest.preview": true,
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,4 +1,5 @@
-@import "tailwindcss";
+@import 'tailwindcss';
+@import 'tailwindcss/preflight';
 @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css");
 
 @font-face {
@@ -87,125 +88,122 @@ html, body {
   }
 }
 /* 색상 */
-@layer utilities {
-  /* Mint */
-  .bg-mint-50 { background-color: var(--mint-50); }
-  .bg-mint-100 { background-color: var(--mint-100); }
-  .bg-mint-200 { background-color: var(--mint-200); }
-  .bg-mint-300 { background-color: var(--mint-300); }
-  .bg-mint-400 { background-color: var(--mint-400); }
-  .bg-mint-500 { background-color: var(--mint-500); }
-  .bg-mint-600 { background-color: var(--mint-600); }
-  .bg-mint-700 { background-color: var(--mint-700); }
-  .bg-mint-800 { background-color: var(--mint-800); }
-  .bg-mint-900 { background-color: var(--mint-900); }
-  .text-mint-50 { color: var(--mint-50); }
-  .text-mint-100 { color: var(--mint-100); }
-  .text-mint-200 { color: var(--mint-200); }
-  .text-mint-300 { color: var(--mint-300); }
-  .text-mint-400 { color: var(--mint-400); }
-  .text-mint-500 { color: var(--mint-500); }
-  .text-mint-600 { color: var(--mint-600); }
-  .text-mint-700 { color: var(--mint-700); }
-  .text-mint-800 { color: var(--mint-800); }
-  .text-mint-900 { color: var(--mint-900); }
+/* Mint */
+@utility bg-mint-50 { background-color: var(--mint-50); }
+@utility bg-mint-100 { background-color: var(--mint-100); }
+@utility bg-mint-200 { background-color: var(--mint-200); }
+@utility bg-mint-300 { background-color: var(--mint-300); }
+@utility bg-mint-400 { background-color: var(--mint-400); }
+@utility bg-mint-500 { background-color: var(--mint-500); }
+@utility bg-mint-600 { background-color: var(--mint-600); }
+@utility bg-mint-700 { background-color: var(--mint-700); }
+@utility bg-mint-800 { background-color: var(--mint-800); }
+@utility bg-mint-900 { background-color: var(--mint-900); }
 
-  /* Pink */
-  .bg-pink-50 { background-color: var(--pink-50); }
-  .bg-pink-100 { background-color: var(--pink-100); }
-  .bg-pink-200 { background-color: var(--pink-200); }
-  .bg-pink-300 { background-color: var(--pink-300); }
-  .bg-pink-400 { background-color: var(--pink-400); }
-  .bg-pink-500 { background-color: var(--pink-500); }
-  .bg-pink-600 { background-color: var(--pink-600); }
-  .bg-pink-700 { background-color: var(--pink-700); }
-  .bg-pink-800 { background-color: var(--pink-800); }
-  .bg-pink-900 { background-color: var(--pink-900); }
-  .text-pink-50 { color: var(--pink-50); }
-  .text-pink-100 { color: var(--pink-100); }
-  .text-pink-200 { color: var(--pink-200); }
-  .text-pink-300 { color: var(--pink-300); }
-  .text-pink-400 { color: var(--pink-400); }
-  .text-pink-500 { color: var(--pink-500); }
-  .text-pink-600 { color: var(--pink-600); }
-  .text-pink-700 { color: var(--pink-700); }
-  .text-pink-800 { color: var(--pink-800); }
-  .text-pink-900 { color: var(--pink-900); }
+@utility text-mint-50 { color: var(--mint-50); }
+@utility text-mint-100 { color: var(--mint-100); }
+@utility text-mint-200 { color: var(--mint-200); }
+@utility text-mint-300 { color: var(--mint-300); }
+@utility text-mint-400 { color: var(--mint-400); }
+@utility text-mint-500 { color: var(--mint-500); }
+@utility text-mint-600 { color: var(--mint-600); }
+@utility text-mint-700 { color: var(--mint-700); }
+@utility text-mint-800 { color: var(--mint-800); }
+@utility text-mint-900 { color: var(--mint-900); }
 
-  /* Gray */
-  .bg-gray-50 { background-color: var(--gray-50); }
-  .bg-gray-100 { background-color: var(--gray-100); }
-  .bg-gray-200 { background-color: var(--gray-200); }
-  .bg-gray-300 { background-color: var(--gray-300); }
-  .bg-gray-400 { background-color: var(--gray-400); }
-  .bg-gray-500 { background-color: var(--gray-500); }
-  .bg-gray-600 { background-color: var(--gray-600); }
-  .bg-gray-700 { background-color: var(--gray-700); }
-  .bg-gray-800 { background-color: var(--gray-800); }
-  .bg-gray-900 { background-color: var(--gray-900); }
-  .text-gray-50 { color: var(--gray-50); }
-  .text-gray-100 { color: var(--gray-100); }
-  .text-gray-200 { color: var(--gray-200); }
-  .text-gray-300 { color: var(--gray-300); }
-  .text-gray-400 { color: var(--gray-400); }
-  .text-gray-500 { color: var(--gray-500); }
-  .text-gray-600 { color: var(--gray-600); }
-  .text-gray-700 { color: var(--gray-700); }
-  .text-gray-800 { color: var(--gray-800); }
-  .text-gray-900 { color: var(--gray-900); }
+/* Pink */
+@utility bg-pink-50 { background-color: var(--pink-50)!important; }
+@utility bg-pink-100 { background-color: var(--pink-100)!important; }
+@utility bg-pink-200 { background-color: var(--pink-200)!important; }
+@utility bg-pink-300 { background-color: var(--pink-300)!important; }
+@utility bg-pink-400 { background-color: var(--pink-400)!important; }
+@utility bg-pink-500 { background-color: var(--pink-500)!important;}
+@utility bg-pink-600 { background-color: var(--pink-600)!important; }
+@utility bg-pink-700 { background-color: var(--pink-700)!important; }
+@utility bg-pink-800 { background-color: var(--pink-800)!important; }
+@utility bg-pink-900 { background-color: var(--pink-900)!important; }
 
-  /* Blue */
-  .bg-blue-400 { background-color: var(--blue-400); }
-  .text-blue-400 { color: var(--blue-400); }
+@utility text-pink-50 { color: var(--pink-50)!important; }
+@utility text-pink-100 { color: var(--pink-100)!important; }
+@utility text-pink-200 { color: var(--pink-200)!important; }
+@utility text-pink-300 { color: var(--pink-300)!important;}
+@utility text-pink-400 { color: var(--pink-400)!important; }
+@utility text-pink-500 { color: var(--pink-500)!important; }
+@utility text-pink-600 { color: var(--pink-600)!important; }
+@utility text-pink-700 { color: var(--pink-700)!important; }
+@utility text-pink-800 { color: var(--pink-800)!important; }
+@utility text-pink-900 { color: var(--pink-900)!important; }
 
-  /* Red */
-  .bg-red-300 { background-color: var(--red-300); }
-  .bg-red-400 { background-color: var(--red-400); }
-  .text-red-300 { color: var(--red-300); }
-  .text-red-400 { color: var(--red-400); }
+/* Gray */
+@utility bg-gray-50 { background-color: var(--gray-50)!important; }
+@utility bg-gray-100 { background-color: var(--gray-100)!important; }
+@utility bg-gray-200 { background-color: var(--gray-200)!important; }
+@utility bg-gray-300 { background-color: var(--gray-300)!important; }
+@utility bg-gray-400 { background-color: var(--gray-400)!important; }
+@utility bg-gray-500 { background-color: var(--gray-500)!important; }
+@utility bg-gray-600 { background-color: var(--gray-600)!important; }
+@utility bg-gray-700 { background-color: var(--gray-700)!important; }
+@utility bg-gray-800 { background-color: var(--gray-800)!important; }
+@utility bg-gray-900 { background-color: var(--gray-900)!important; }
 
-  /* Background / Foreground */
-  .bg-background { background-color: var(--background); }
-  .bg-foreground { background-color: var(--foreground); }
-  .text-background { color: var(--background); }
-  .text-foreground { color: var(--foreground); }
-}
-/* 폰트 */
-@layer utilities {
-  /* Pretendard */
-  .text-display-lg { font-size:5.7rem; font-weight:300; line-height:6.4rem; letter-spacing:-0.025rem; font-family: var(--font-sans); }
-  .text-display-md { font-size:5.2rem; font-weight:300; line-height:4.5rem; font-family: var(--font-sans); }
-  .text-display-sm { font-size:3.6rem; font-weight:300; line-height:4.4rem; font-family: var(--font-sans); }
+@utility text-gray-50 { color: var(--gray-50)!important; }
+@utility text-gray-100 { color: var(--gray-100)!important; }
+@utility text-gray-200 { color: var(--gray-200)!important; }
+@utility text-gray-300 { color: var(--gray-300)!important; }
+@utility text-gray-400 { color: var(--gray-400)!important; }
+@utility text-gray-500 { color: var(--gray-500)!important; }
+@utility text-gray-600 { color: var(--gray-600)!important; }
+@utility text-gray-700 { color: var(--gray-700)!important; }
+@utility text-gray-800 { color: var(--gray-800)!important; }
+@utility text-gray-900 { color: var(--gray-900)!important; }
 
-  .text-headline-lg { font-size:3.2rem; font-weight:200; line-height:4rem; font-family: var(--font-sans); }
-  .text-headline-md { font-size:2.8rem; font-weight:200; line-height:3.2rem; font-family: var(--font-sans); }
-  .text-headline-sm { font-size:2.4rem; font-weight:200; line-height:3.2rem; font-family: var(--font-sans); }
+/* Blue */
+@utility bg-blue-400 { background-color: var(--blue-400)!important; }
+@utility text-blue-400 { color: var(--blue-400)!important; }
 
-  .text-title-lg { font-size:2.2rem; font-weight:400; line-height:1.75rem; font-family: var(--font-sans); }
-  .text-title-md { font-size:1.6rem; font-weight:400; line-height:2.4rem; letter-spacing:0.015rem; font-family: var(--font-sans); }
-  .text-title-sm { font-size:1.4rem; font-weight:400; line-height:2rem; letter-spacing:0.01rem; font-family: var(--font-sans); }
+/* Red */
+@utility bg-red-300 { background-color: var(--red-300)!important; }
+@utility bg-red-400 { background-color: var(--red-400)!important; }
+@utility text-red-300 { color: var(--red-300)!important; }
+@utility text-red-400 { color: var(--red-400)!important; }
 
-  .text-label-lg { font-size:1.4rem; font-weight:300; line-height:2rem; font-family: var(--font-sans); }
-  .text-label-md { font-size:1.2rem; font-weight:300; line-height:1.6rem; font-family: var(--font-sans); }
-  .text-label-sm { font-size:1.1rem; font-weight:300; line-height:1.6rem; font-family: var(--font-sans); }
+/* Background / Foreground */
+@utility bg-background { background-color: var(--background); }
+@utility bg-foreground { background-color: var(--foreground); }
+@utility text-background { color: var(--background); }
+@utility text-foreground { color: var(--foreground); }
 
-  /* JEN Serif */
-  .text-display-serif { font-size:3.6rem; font-weight:200; line-height:4.6rem; letter-spacing:0.6rem; font-family: var(--font-serif); }
-  .text-headline-lg-serif { font-size:3.2rem; font-weight:200; line-height:4rem; letter-spacing:0.2rem; font-family: var(--font-serif); }
-  .text-headline-md-serif { font-size:2.4rem; font-weight:200; line-height:3.2rem; letter-spacing:0.2rem; font-family: var(--font-serif); }
-  .text-headline-sm-serif { font-size:2rem; font-weight:200; line-height:2.4rem; letter-spacing:1.2rem; font-family: var(--font-serif); }
-  .text-label-serif { font-size:1.4rem; font-weight:200; line-height:2rem; letter-spacing:0.4rem; font-family: var(--font-serif); }
-}
-  /*display, grid 참조 */
-@layer utilities {
 
-  .layout-flex { display: var(--display-flex); }
-  .layout-grid { display: var(--display-grid); }
+/* 폰트 *//* Pretendard */
+@utility text-display-lg { font-size:5.7rem; font-weight:300; line-height:6.4rem; letter-spacing:-0.025rem; font-family: var(--font-sans); }
+@utility text-display-md { font-size:5.2rem; font-weight:300; line-height:4.5rem; font-family: var(--font-sans); }
+@utility text-display-sm { font-size:3.6rem; font-weight:300; line-height:4.4rem; font-family: var(--font-sans); }
 
-  .grid-cols-6 { grid-template-columns: var(--grid-cols-6); }
-  .grid-cols-4 { grid-template-columns: var(--grid-cols-4); }
+@utility text-headline-lg { font-size:3.2rem; font-weight:200; line-height:4rem; font-family: var(--font-sans); }
+@utility text-headline-md { font-size:2.8rem; font-weight:200; line-height:3.2rem; font-family: var(--font-sans); }
+@utility text-headline-sm { font-size:2.4rem; font-weight:200; line-height:3.2rem; font-family: var(--font-sans); }
 
-  .max-w-mobile { max-width: var(--max-w-mobile); }
-  .min-w-100 { min-width: var(--min-w-100); }
-}
+@utility text-title-lg { font-size:2.2rem; font-weight:400; line-height:1.75rem; font-family: var(--font-sans); }
+@utility text-title-md { font-size:1.6rem; font-weight:400; line-height:2.4rem; letter-spacing:0.015rem; font-family: var(--font-sans); }
+@utility text-title-sm { font-size:1.4rem; font-weight:400; line-height:2rem; letter-spacing:0.01rem; font-family: var(--font-sans); }
 
+@utility text-label-lg { font-size:1.4rem; font-weight:300; line-height:2rem; font-family: var(--font-sans); }
+@utility text-label-md { font-size:1.2rem; font-weight:300; line-height:1.6rem; font-family: var(--font-sans); }
+@utility text-label-sm { font-size:1.1rem; font-weight:300; line-height:1.6rem; font-family: var(--font-sans); }
+
+/* JEN Serif */
+@utility text-display-serif { font-size:3.6rem; font-weight:200; line-height:4.6rem; letter-spacing:0.6rem; font-family: var(--font-serif); }
+@utility text-headline-lg-serif { font-size:3.2rem; font-weight:200; line-height:4rem; letter-spacing:0.2rem; font-family: var(--font-serif); }
+@utility text-headline-md-serif { font-size:2.4rem; font-weight:200; line-height:3.2rem; letter-spacing:0.2rem; font-family: var(--font-serif); }
+@utility text-headline-sm-serif { font-size:2rem; font-weight:200; line-height:2.4rem; letter-spacing:1.2rem; font-family: var(--font-serif); }
+@utility text-label-serif { font-size:1.4rem; font-weight:200; line-height:2rem; letter-spacing:0.4rem; font-family: var(--font-serif); }
+
+/* Layout */
+@utility layout-flex { display: var(--display-flex); }
+@utility layout-grid { display: var(--display-grid); }
+
+@utility grid-cols-6 { grid-template-columns: var(--grid-cols-6); }
+@utility grid-cols-4 { grid-template-columns: var(--grid-cols-4); }
+
+@utility max-w-mobile { max-width: var(--max-w-mobile); }
+@utility min-w-100 { min-width: var(--min-w-100); }


### PR DESCRIPTION
### 🔥 작업 내용
- Tailwind 기본 컬러 보다 커스텀 컬러 우선순위
- Tailwind 유틸리티 자동완성

### 🔗 이슈
- close https://github.com/geulDa/FE/issues/25#issue-3521067412

### PR Point (To Reviewer)
## 컬러 & 텍스트 자동완성 
단순히 커스텀 유틸리티로 구분하면 Tailwind  v4에서 config 파일을 사용하지 않기 때문에, Vscode IntelliSense가 인식을 못하는 문제가 있다 합니다.
원활한 작업을 위해...토큰 자동완성 되도록 설정해놨습니다.

## 컬러 우선순위 - 커스텀 컬러로 변경
Tailwind 내 기본 pink, gray가 색상이 겹쳐 커스텀 색상이 우선순위에서 밀리는 문제가 있어
`!important` 를 유틸리티에 추가해 우선순위가 되도록 했습니다.

## 🤔문제는 아니지만 해결하지 못한 부분
1) 조금 거슬리는 것은 캡쳐본 보면..알다시피 컬러칩가 뜨지는 않습니다. 왜이런지는..잘
작업하는데 거슬리면 해결해보겠습니다. 
<img width="675" height="325" alt="image" src="https://github.com/user-attachments/assets/eab2f848-3ce3-46f7-a0fc-2df07354a302" />

2) pink, gray, red, blue 는 컬러칩은 뜹니다. Tailwind 기본 색상이라 오해할까봐 적어두면
보시면 `!important` 를 적어둔 것이 적용된 걸 확인할 수 있습니다. (밑에 기본 Tailwind는 덮어씌어짐)
<img width="761" height="227" alt="image" src="https://github.com/user-attachments/assets/0a7b3695-66ea-4a0e-bd48-720a95ab0b90" />


### 📸 피그마 스크린샷 or 기능 GIF
자동완성 뜹니다 
<img width="919" height="364" alt="image" src="https://github.com/user-attachments/assets/0b517016-0994-4ef7-9c48-747c6206afe5" />

<img width="485" height="331" alt="image" src="https://github.com/user-attachments/assets/fc5edc95-aaee-4621-96da-d188ac1393f5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added VSCode configuration with Tailwind CSS intellisense and editor autocompletion enhancements.
  * Restructured stylesheet utility system architecture and declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->