### PR TITLE
⚙️Setting : 폰트 weight 커스텀 및 자간행간 재설정

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -178,34 +178,41 @@ html, body {
 @utility text-background { color: var(--background); }
 @utility text-foreground { color: var(--foreground); }
 
-
 /* 폰트 *//* Pretendard */
-@utility text-display-lg { font-size:5.7rem; font-family: var(--font-sans); }
-@utility text-display-md { font-size:5.2rem; font-family: var(--font-sans); }
-@utility text-display-sm { font-size:3.6rem; font-family: var(--font-sans); }
+@utility text-display-lg { font-size:5.7rem; line-height: 6.4rem; letter-spacing: -0.025em; font-family: var(--font-sans); }
+@utility text-display-md { font-size:5.2rem; line-height: 4.5rem; font-family: var(--font-sans); }
+@utility text-display-sm { font-size:3.6rem; line-height: 4.4rem; font-family: var(--font-sans); }
 
-@utility text-headline-lg { font-size:3.2rem; font-family: var(--font-sans); }
-@utility text-headline-md { font-size:2.8rem; font-family: var(--font-sans); }
-@utility text-headline-sm { font-size:2.4rem; font-family: var(--font-sans); }
+@utility text-headline-lg { font-size:3.2rem; line-height: 4rem; font-family: var(--font-sans); }
+@utility text-headline-md { font-size:2.8rem; line-height: 3.2rem; font-family: var(--font-sans); }
+@utility text-headline-sm { font-size:2.4rem; line-height: 3.2rem; font-family: var(--font-sans); }
 
-@utility text-title-lg { font-size:2.2rem;  font-family: var(--font-sans); }
-@utility text-title-md { font-size:1.6rem;  font-family: var(--font-sans); }
-@utility text-title-sm { font-size:1.4rem; font-family: var(--font-sans); }
+@utility text-title-lg { font-size:2.2rem; line-height: 2.8rem; letter-spacing: 0.015em; font-family: var(--font-sans); }
+@utility text-title-md { font-size:1.6rem; line-height: 2.4rem; letter-spacing: 0.01em; font-family: var(--font-sans); }
+@utility text-title-sm { font-size:1.4rem; line-height: 2rem; letter-spacing: 0.01em; font-family: var(--font-sans); }
 
-@utility text-label-lg { font-size:1.4rem; font-family: var(--font-sans); }
-@utility text-label-md { font-size:1.2rem; font-family: var(--font-sans); }
-@utility text-label-sm { font-size:1.1rem; font-family: var(--font-sans); }
+@utility text-label-lg { font-size:1.4rem; line-height: 2rem; letter-spacing: 0.01em; font-family: var(--font-sans); }
+@utility text-label-md { font-size:1.2rem; line-height: 1.6rem; letter-spacing: 0.05em; font-family: var(--font-sans); }
+@utility text-label-sm { font-size:1.1rem; line-height: 1.6rem; letter-spacing: 0.05em; font-family: var(--font-sans); }
 
-@utility text-body-lg { font-size:1.4rem; font-family: var(--font-sans); }
-@utility text-body-md { font-size:1.2rem; font-family: var(--font-sans); }
-@utility text-body-sm { font-size:1rem; font-family: var(--font-sans); }
+@utility text-body-lg { font-size:1.4rem; line-height: 2.4rem; letter-spacing: 0.05em; font-family: var(--font-sans); }
+@utility text-body-md { font-size:1.2rem; line-height: 2rem; letter-spacing: 0.025em; -family: var(--font-sans); }
+@utility text-body-sm { font-size:1rem; line-height: 1.6rem; letter-spacing: 0.04em; font-family: var(--font-sans); }
 
 /* JEN Serif */
-@utility text-display-serif { font-size:3.6rem; font-family: var(--font-serif); }
-@utility text-headline-lg-serif { font-size:3.2rem; font-family: var(--font-serif); }
-@utility text-headline-md-serif { font-size:2.4rem; font-family: var(--font-serif); }
-@utility text-headline-sm-serif { font-size:2rem; font-family: var(--font-serif); }
-@utility text-label-serif { font-size:1.4rem; font-family: var(--font-serif); }
+@utility text-display-serif { font-size:3.6rem; line-height: 4.6rem; letter-spacing: 0.6em; font-family: var(--font-serif); }
+@utility text-headline-lg-serif { font-size:3.2rem; line-height: 4rem; letter-spacing: 0.2em; font-family: var(--font-serif); }
+@utility text-headline-md-serif { font-size:2.4rem; line-height: 3.2rem; letter-spacing: 0.2em; font-family: var(--font-serif); }
+@utility text-headline-sm-serif { font-size:2rem; line-height: 2.4rem; letter-spacing: 1.2rem;  font-family: var(--font-serif); }
+@utility text-label-serif { font-size:1.4rem; line-height: 2rem; letter-spacing: 0.4rem; font-family: var(--font-serif); }
+
+/* font-weight */
+@utility font-light { font-weight: 100 !important; }
+@utility font-regular { font-weight: 200 !important; }
+@utility font-medium { font-weight: 300 !important; }
+@utility font-semibold { font-weight: 400 !important; }
+@utility font-bold { font-weight: 500 !important; }
+
 
 /* Layout */
 @utility layout-flex { display: var(--display-flex); }
@@ -218,3 +225,4 @@ html, body {
 
 @utility max-w-mobile { max-width: var(--max-w-mobile); }
 @utility min-w-100 { min-width: var(--min-w-100); }
+


### PR DESCRIPTION
### 🔥 작업 내용
- 폰트 weight 커스텀 및 자간행간 재설정

### PR Point (To Reviewer)
## 피그마 내 작업방식 차이
피그마 내 작업방식 차이로 ^^ 디자인 시스템 표대로 자간 행간 다시 추가해뒀습니다.
기본적인 **자간 행간**은 적용해둔 상태이고 font-weight 값만 디자인 따라 따로 지정해주면 됩니다.
<img width="320" height="308" alt="1" src="https://github.com/user-attachments/assets/444eec3a-678b-4a9a-9b1f-bbab9c43f3bb" />


## font-weight 커스텀
Tailwind는 기본 weight 값이 있어 저희 디자인 시스템이랑 차이가 있어 바꿔뒀습니다 :) 
밑에는 Tailwind 기본 값이랑 / 커스텀 한 값 사진입니다
<img width="1050" height="1058" alt="image" src="https://github.com/user-attachments/assets/1647bc83-42d7-4f8a-afc3-d0dd8852b20a" />
<img width="658" height="199" alt="image" src="https://github.com/user-attachments/assets/60a1d83d-52ec-46a2-b3e6-19818647a35f" />

##사용 예시
```
 <p className="text-display-lg font-light text-gray-900">text-display-lg font-light</p>
 /* text-display-lg : 폰트 스타일 / 사이즈 / 자간 * 행간  - 값 */
 /* text-light :  커스텀 폰트 weight 값(100) */
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 글꼴 두께 유틸리티 추가 (light, regular, medium, semibold, bold)
* 레이아웃 그리드 유틸리티 추가

## 개선 사항
* 모든 텍스트 스타일에 줄 높이 및 자간 추가로 타이포그래피 개선
* JEN Serif 타이포그래피 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->