### PR TITLE
🐛Fix & Setting : 폰트 유틸리티 다시 초기 세팅 

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -196,7 +196,7 @@ html, body {
 @utility text-label-sm { font-size:1.1rem; line-height: 1.6rem; font-weight: 300; letter-spacing: 0.05em; font-family: var(--font-sans); }
 
 @utility text-body-lg { font-size:1.4rem; line-height: 2.4rem; font-weight: 400; letter-spacing: 0.05em; font-family: var(--font-sans); }
-@utility text-body-md { font-size:1.2rem; line-height: 2rem; font-weight: 300; letter-spacing: 0.025em; -family: var(--font-sans); }
+@utility text-body-md { font-size:1.2rem; line-height: 2rem; font-weight: 300; letter-spacing: 0.025em; font-family: var(--font-sans); }
 @utility text-body-sm { font-size:1rem; line-height: 1.6rem; font-weight: 200; letter-spacing: 0.04em; font-family: var(--font-sans); }
 
 /* JEN Serif */


### PR DESCRIPTION
### 🔥 작업 내용
- 디자이너 말 제대로 듣지 않아. 다시 초기 세팅으로 돌려놨습니다.


### PR Point (To Reviewer)
## Weight 값 맞는지만 확인 부탁드립니다.
디자이너가 자기가 이 부분이 왜 이렇게 되는지 모르겠지만, 무시하고 디자인시스템 표대로 해달라고 합니다.
기준은 이름 기준으로 작성하면 됩니다. (굵기 신경쓰지 말고)
<img width="740" height="391" alt="image" src="https://github.com/user-attachments/assets/d79f7c16-93e4-4398-8894-30b99278a08c" />
<img width="1246" height="975" alt="image" src="https://github.com/user-attachments/assets/3d546778-dae1-4d20-889b-ba541a77b23b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 텍스트 타이포그래피 유틸리티에 폰트 굵기(200, 300, 400)가 추가되어 디스플레이, 헤드라인, 제목, 라벨, 본문 및 세리프 변형 전반의 가시적 일관성이 향상되었습니다.
  * 세리프 변형에도 일관된 폰트 굵기 적용으로 스타일 통일성 강화.

* **Bug Fixes**
  * 본문 유틸리티의 폰트 선언 오타를 수정했습니다.

* **Chores**
  * 별도 폰트-굵기 유틸리티 세트 제거로 관리 간소화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->