### PR TITLE
🔧 Chore & ✨ Feat: axios 인스턴스 커스텀, 토큰 자동 재발급 구현

### DIFF
--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -38,7 +38,7 @@ let failedQueue: {
   reject: (error: unknown) => void;
 }[] = [];
 
-const processQueue = (error: any, token: string | null = null) => {
+const processQueue = (error: unknown, token: string | null = null) => {
   failedQueue.forEach((prom) => {
     if (error) prom.reject(error);
     else prom.resolve(token ?? '');

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosError } from 'axios';
+import type { InternalAxiosRequestConfig } from 'axios';
 import {
   getAccessToken,
   getRefreshToken,
@@ -49,7 +50,7 @@ const processQueue = (error: unknown, token: string | null = null) => {
 apiWithToken.interceptors.response.use(
   (response) => response,
   async (error: AxiosError<ApiResponse<unknown>>) => {
-    const originalRequest = error.config as any;
+    const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
 
     if (error.response?.status === 401 && !originalRequest._retry) {
       if (isRefreshing) {

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -88,7 +88,9 @@ apiWithToken.interceptors.response.use(
       } catch (err) {
         processQueue(err, null);
         clearTokens();
-        window.location.href = '/login';
+        if (typeof window !== 'undefined') {
+          window.location.href = '/login';
+        }
         return Promise.reject(err);
       } finally {
         isRefreshing = false;

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -1,0 +1,99 @@
+import axios, { AxiosError } from 'axios';
+import {
+  getAccessToken,
+  getRefreshToken,
+  setTokens,
+  clearTokens,
+} from '@/shared/utils/token';
+import type { ApiResponse, TokenData } from '@/shared/api/types';
+
+const BASE_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
+
+//토큰이 필요한 요청용 인스턴스
+export const apiWithToken = axios.create({
+  baseURL: BASE_URL,
+  withCredentials: true,
+});
+
+// 토큰이 필요 없는 요청용 인스턴스
+export const apiAuth = axios.create({
+  baseURL: BASE_URL,
+  withCredentials: true,
+});
+
+// 요청 인터셉터 - 액세스 토큰 첨부
+apiWithToken.interceptors.request.use(
+  (config) => {
+    const token = getAccessToken();
+    if (token) config.headers.Authorization = `Bearer ${token}`;
+    return config;
+  },
+  (error) => Promise.reject(error),
+);
+
+// 응답 인터셉터 - 토큰 재발급 처리
+let isRefreshing = false;
+let failedQueue: {
+  resolve: (token?: string) => void;
+  reject: (error: any) => void;
+}[] = [];
+
+const processQueue = (error: any, token: string | null = null) => {
+  failedQueue.forEach((prom) => {
+    if (error) prom.reject(error);
+    else prom.resolve(token ?? '');
+  });
+  failedQueue = [];
+};
+
+apiWithToken.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError<ApiResponse<unknown>>) => {
+    const originalRequest = error.config as any;
+
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          failedQueue.push({
+            resolve: (token?: string) => {
+              originalRequest.headers.Authorization = 'Bearer ' + token;
+              resolve(apiWithToken(originalRequest));
+            },
+            reject,
+          });
+        });
+      }
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      try {
+        // refreshToken 가져옴
+        const refreshToken = getRefreshToken();
+
+        const { data } = await axios.post<ApiResponse<TokenData>>(
+          `${BASE_URL}/api/auth/token/refresh`,
+          { refreshToken },
+          { withCredentials: true },
+        );
+
+        const { accessToken, refreshToken: newRefresh } = data.data;
+        setTokens(accessToken, newRefresh);
+
+        apiWithToken.defaults.headers.common.Authorization = 'Bearer ' + accessToken;
+        processQueue(null, accessToken);
+
+        return apiWithToken(originalRequest);
+      } catch (err) {
+        processQueue(err, null);
+        clearTokens();
+        window.location.href = '/login';
+        return Promise.reject(err);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
+    return Promise.reject(error);
+  },
+);

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -35,7 +35,7 @@ apiWithToken.interceptors.request.use(
 let isRefreshing = false;
 let failedQueue: {
   resolve: (token?: string) => void;
-  reject: (error: any) => void;
+  reject: (error: unknown) => void;
 }[] = [];
 
 const processQueue = (error: any, token: string | null = null) => {
@@ -80,7 +80,8 @@ apiWithToken.interceptors.response.use(
         const { accessToken, refreshToken: newRefresh } = data.data;
         setTokens(accessToken, newRefresh);
 
-        apiWithToken.defaults.headers.common.Authorization = 'Bearer ' + accessToken;
+        apiWithToken.defaults.headers.common.Authorization =
+          'Bearer ' + accessToken;
         processQueue(null, accessToken);
 
         return apiWithToken(originalRequest);

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -1,0 +1,13 @@
+export interface ApiResponse<T> {
+  success: boolean;
+  code: string;
+  message: string;
+  data: T;
+}
+
+export interface TokenData {
+  accessToken: string;
+  refreshToken: string;
+  tokenType: string;
+  expiresIn: number;
+}

--- a/src/shared/utils/token.ts
+++ b/src/shared/utils/token.ts
@@ -1,15 +1,21 @@
 const ACCESS_TOKEN_KEY = 'accessToken';
 const REFRESH_TOKEN_KEY = 'refreshToken';
+const isBrowser =
+  typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
 
-export const getAccessToken = () => localStorage.getItem(ACCESS_TOKEN_KEY);
-export const getRefreshToken = () => localStorage.getItem(REFRESH_TOKEN_KEY);
+export const getAccessToken = () =>
+  isBrowser ? localStorage.getItem(ACCESS_TOKEN_KEY) : null;
+export const getRefreshToken = () =>
+  isBrowser ? localStorage.getItem(REFRESH_TOKEN_KEY) : null;
 
 export const setTokens = (accessToken: string, refreshToken: string) => {
+  if (!isBrowser) return;
   localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
   localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
 };
 
 export const clearTokens = () => {
+  if (!isBrowser) return;
   localStorage.removeItem(ACCESS_TOKEN_KEY);
   localStorage.removeItem(REFRESH_TOKEN_KEY);
 };

--- a/src/shared/utils/token.ts
+++ b/src/shared/utils/token.ts
@@ -1,0 +1,15 @@
+const ACCESS_TOKEN_KEY = 'accessToken';
+const REFRESH_TOKEN_KEY = 'refreshToken';
+
+export const getAccessToken = () => localStorage.getItem(ACCESS_TOKEN_KEY);
+export const getRefreshToken = () => localStorage.getItem(REFRESH_TOKEN_KEY);
+
+export const setTokens = (accessToken: string, refreshToken: string) => {
+  localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+  localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+};
+
+export const clearTokens = () => {
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+  localStorage.removeItem(REFRESH_TOKEN_KEY);
+};


### PR DESCRIPTION
### 🔥 작업 내용
- axios 커스텀 인스턴스 생성(instance.ts)
- apiWithToken / apiAuth 인스턴스로 분리
- 액세스 토큰 자동 첨부 
- 401 발생 시 리프래시 토큰 자동 재발급

### 🤔 추후 작업 사항
- [ ] 실제 잘 작동하는지 여부

### 🔗 이슈
- close #https://github.com/geulDa/FE/issues/90

### PR Point (To Reviewer)
## axios 인스턴스 커스텀
axios 커스텀을 통해 `baseURL`,` Authorization` 등 의 공통 설정을` instance.ts `에서 관리할 수 있도록 했습니다. 리프래시 토큰, 액세스 토큰 재발급 등의 로직을 추가로 따로 토큰 처리를 설정하지 않아도
`apiWithToken.get()` , `apiAuth.post() `를 호출 시 자동 처리 될 예정입니다.(테스트는 해봐야 겠지만)
동시에 여러 요청이 발생하더라도 `failedQueue`를 통해 토큰 재발급이 한 번만 이루어지도록 했습니다.

## 인스턴스 분리( apiWithToken / apiAuth )
JWT 인증이 필요한 시점이 다른 경우가 있어
사용자 인증 흐름을 위해 2가지로 분리했습니다. 용도는 다음과 같습니다.

```
apiAuth: 로그인, 임시 토큰 교환 등 인증 전 요청용
apiWithToken: 로그인 후 JWT가 필요한 요청용
```
**결론 : 로그인 전 or 비회원로그인 apiAuth, 로그인 후에는 apiWithToken만 쓰면 됩니다.**

## 사용방법
**1. 로그인 전(비회원로그인) - JWT X**
```
import { apiAuth } from '@/shared/api/instance';

const { data } = await apiAuth.post('/api/auth/temp-token/exchange', { tempToken });
setTokens(data.data.accessToken, data.data.refreshToken);
```

**2. 로그인 후 -JWT O**
```
import { apiWithToken } from '@/shared/api/instance';

// ex) : 마이페이지 유저 정보 조회
const { data } = await apiWithToken.get('/api/members/mypage');
```

**3. 특정 페이지 내 데이터 요청**
```
ex) 명소 정보
import { apiWithToken } from '@/shared/api/instance';

const { data } = await apiWithToken.get('/api/places/{placeId}');
return data.data; 

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 인증 토큰 자동 갱신 및 재시도 로직이 도입되어 만료된 요청을 자동으로 재시도합니다.
  * 토큰 저장·조회·삭제가 중앙에서 관리됩니다.

* **개선사항**
  * 갱신 중 중복 요청을 대기시켜 일관된 재인증 처리 보장.
  * 갱신 실패 시 토큰이 정리되고 로그인 화면으로 이동하여 보안이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->