### PR TITLE
fix&refactor: 로딩 상태 스켈레톤 ui

### DIFF
--- a/src/shared/components/skeleton/Skeleton.tsx
+++ b/src/shared/components/skeleton/Skeleton.tsx
@@ -1,0 +1,8 @@
+// src/shared/components/ui/Skeleton.tsx
+import { cn } from '@/shared/lib';
+
+export const Skeleton = ({ className }: { className?: string }) => {
+  return (
+    <div className={cn('animate-pulse bg-gray-200 rounded-md', className)} />
+  );
+};


### PR DESCRIPTION
### 🔥 작업 내용
- 노드페이지 로딩 상태 스켈레톤 ui
    - 1초 이상 로딩일 때 전체 페이지 스켈레톤 뜨게했고
    - 이미지만 늦게 도착하는거같길래 이미지만 따로 추가적으로 스켈레톤ui 처리 해둿습니다 

### 🤔 추후 작업 사항
- ex) 소셜 로그인 연동 (카카오, 구글)
- 

### 🔗 이슈
- close #

### PR Point (To Reviewer)
- ex) 로그인 입력 검증 로직 적절한지 확인 부탁드립니다.
- 

### 📸 피그마 스크린샷 or 기능 GIF
(작업 내역 스크린샷)
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/4733d534-d2ce-49f0-acbc-75722d35d7bf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 이미지 로딩 중 스켈레톤 플레이스홀더 추가로 더 나은 로딩 경험 제공
  * 1초 지연 후 스켈레톤 표시로 깜빡임 방지
  * 이미지 로딩 완료 시 페이드 트랜지션 효과 적용
  * 이미지 로드 완료 후에만 스탬프 버튼 표시

* **Bug Fixes**
  * 미로그인 사용자의 스탬프 기능 접근 제한

<!-- end of auto-generated comment: release notes by coderabbit.ai -->