### PR TITLE
Refactor: web-app-accessibility 웹앱 공통 사이즈 적용

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,6 +3,7 @@ import '@/shared/icons';
 import { useState } from 'react';
 import type { AppProps } from 'next/app';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import AppLayout from '@/shared/layout/AppLayout';
 
 export default function App({ Component, pageProps }: AppProps) {
   const [queryClient] = useState(
@@ -13,12 +14,14 @@ export default function App({ Component, pageProps }: AppProps) {
             staleTime: 60 * 1000,
           },
         },
-      }),
+      })
   );
 
   return (
     <QueryClientProvider client={queryClient}>
-      <Component {...pageProps} />
+      <AppLayout>
+        <Component {...pageProps} />
+      </AppLayout>
     </QueryClientProvider>
   );
 }

--- a/src/shared/layout/AppLayout.tsx
+++ b/src/shared/layout/AppLayout.tsx
@@ -1,0 +1,7 @@
+export default function AppLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="app-wrapper">
+      {children}
+    </div>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -13,6 +13,23 @@ html, body {
   font-family: var(--font-sans);
 }
 
+.app-wrapper {
+  width: 100%;
+  max-width: 402px; 
+  margin: 0 auto;          
+  position: relative;  
+  min-height: 100vh;
+  background: var(--background);
+  overflow-x: hidden;  
+  transform: translateZ(0);
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .app-wrapper {
+    width: 100%;
+    max-width: none;
+  }
+}
 
 @theme {
      /* 메인컬러(MAIN) → mint */


### PR DESCRIPTION
### 🔥 작업 내용
- 전체 페이지 공통 Layout(`AppLayout`) 적용  
  - 데스크탑 환경에서 최대 폭 402px 모바일 프레임 고정 및 중앙 정렬  
  - 모바일 디바이스에서는 100% 폭으로 자연스럽게 확장되도록 반응형 처리  
- 기존 fixed/absolute 요소들이 화면 밖으로 벗어나던 문제 해결  
  - 모든 페이지 콘텐츠가 Layout 내부에서만 렌더링되도록 구조 통합  
- 글로벌 스타일(`globals.css`)에서 디바이스 타입별 max-width 분기 적용
  - `@media (hover: none)` 조건으로 모바일 분기 처리
- Layout 적용에 따라 페이지마다 중복되던 여백 및 래퍼 div 제거 → 구조 정리

### 🤔 추후 작업 사항
- 현재는 보류

### 🔗 이슈
- close #135 

### PR Point (To Reviewer)
- 데스크탑(PC 브라우저)에서 402px 영역이 중앙에 고정되는 구조가 적절한지 확인 부탁드립니다.
- 모바일 기기에서 100% 폭으로 자연스럽게 확장되는지 레이아웃 동작 점검 요청드립니다.
- 기존 fixed 요소들이 Layout 안에서만 렌더링되도록 한 구조가 괜찮은지 피드백 부탁드립니다.

### 📸 피그마 스크린샷 or 기능 GIF
(작업 내역 스크린샷)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 앱 레이아웃 구조가 개선되었습니다.
  * 앱 전체를 새로운 컨테이너로 래핑하여 일관된 레이아웃 관리를 제공합니다.
  * 반응형 디자인이 적용되어 터치 기기에서 더 나은 표시 환경을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->