### PR TITLE
🐛Fix : 마이페이지 포스트 카드 조회

### DIFF
--- a/src/pages/mypage/components/PostcardContainer.tsx
+++ b/src/pages/mypage/components/PostcardContainer.tsx
@@ -82,28 +82,28 @@ export default function PostcardContainer({
           postcards.length <= 8 && 'justify-center gap-[1.2rem] ',
         )}
       >
-        {filledSlots.map((card, idx) => (
-          <button
-            key={card?.postcardId ?? idx}
-            onClick={() => card && onClickCard?.(card.postcardId)}
-            disabled={!card}
-            aria-disabled={!card}
-            className={cn(
-              postcardCardStyle({ interactive: !!card }),
-              !card && 'items-center justify-center bg-pink-100',
-            )}
-          >
-            {card && (
+        {filledSlots.map((card, idx) =>
+          card ? (
+            <button
+              key={card.postcardId}
+              onClick={() => onClickCard?.(card.postcardId)}
+              className={postcardCardStyle({ interactive: true })}
+            >
               <Image
-                src={card.imageUrl}
-                alt={card.placeName || `엽서 ${idx + 1}`}
+                src={card.imageUrl.trim()}
+                alt={card.placeName}
                 width={200}
                 height={200}
                 className='w-full h-full object-cover'
               />
-            )}
-          </button>
-        ))}
+            </button>
+          ) : (
+            <div
+              key={idx}
+              className='w-[70px] h-[70px] rounded-[8px] bg-pink-100'
+            />
+          ),
+        )}
       </div>
     </div>
   );

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -14,7 +14,7 @@ import { useMyPageQuery } from '@/shared/api/member';
 
 export default function MyPage() {
   const { isLoggedIn } = useUserStatus();
-  const router = useRouter(); 
+  const router = useRouter();
   const {
     showLoginPopup,
     showLogoutPopup,
@@ -126,10 +126,14 @@ export default function MyPage() {
         </section>
 
         {/* 저장한 엽서 */}
-        <section aria-label='저장한 엽서' className='w-full mt-[1.8rem]'>
+        <section
+          aria-label='저장한 엽서'
+          className='w-full mt-[1.8rem] relative z-[100]'
+        >
           <p className='text-label-lg mb-[0.6rem] pl-[1rem]'>저장한 엽서</p>
           <PostcardContainer
             postcards={!isLoggedIn ? [] : hasPostcards ? postcards : []}
+            onClickCard={(id) => router.push(`/mypage/postcard/${id}`)}
           />
         </section>
 

--- a/src/pages/mypage/postcard/[id].tsx
+++ b/src/pages/mypage/postcard/[id].tsx
@@ -58,7 +58,7 @@ const PostCard = () => {
         )}
       >
         <FlipCard
-          frontSrc={imageUrl}
+          frontSrc={imageUrl.trim()}
           backSrc={imageProps.backSrc}
           width={imageProps.width}
           height={imageProps.height}


### PR DESCRIPTION
### 🔥 작업 내용
- 리다이랙트 경로 변경


### PR Point (To Reviewer)
## 마이페이지 포스트 카드 조회 가능
리다이랙트 경로 변경으로 클릭시 상세 조회 가능하게 해놨습니다. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 저장한 엽서 이미지 URL 처리 개선으로 이미지 표시 안정성 강화
  * 엽서 카드 클릭 시 상세 페이지로 이동하는 네비게이션 기능 추가

* **개선 사항**
  * 저장한 엽서 섹션의 렌더링 성능 최적화
  * 엽서 카드의 대체 텍스트 처리 단순화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->