### PR TITLE
♻️ Refactor : 채팅 로딩 추가 & 북마크 - 상세 페이지만 삭제

### DIFF
--- a/src/pages/chatbot/components/ChattingInput.tsx
+++ b/src/pages/chatbot/components/ChattingInput.tsx
@@ -50,7 +50,7 @@ export default function ChattingInput({
         aria-label='메시지 전송'
         disabled={disabled}
         className={cn(
-          'w-[4rem] h-[4rem] flex justify-center items-center rounded-[2rem] bg-mint-500 flex-shrink-0',
+          'w-[4rem] h-[4rem] flex justify-center items-center rounded-[2rem] bg-pink-200 flex-shrink-0',
         )}
       >
         <Icon name='backto' size={20} color='gray-50' rotate={90} />

--- a/src/pages/chatbot/components/ChattingLoading.tsx
+++ b/src/pages/chatbot/components/ChattingLoading.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+export default function ChattingLoading() {
+  return (
+    <div className='flex items-end gap-[0.35rem] py-[0.4rem]'>
+      <span className='w-[0.8rem] h-[0.8rem] rounded-full bg-pink-50 animate-dot1' />
+      <span className='w-[0.8rem] h-[0.8rem] rounded-full bg-pink-100 animate-dot2' />
+      <span className='w-[0.8rem] h-[0.8rem] rounded-full bg-pink-200 animate-dot3' />
+    </div>
+  );
+}

--- a/src/pages/chatbot/index.tsx
+++ b/src/pages/chatbot/index.tsx
@@ -9,6 +9,7 @@ import { Header } from '@/shared/components';
 import { useChatbot } from '@/shared/hooks/chatbot/useChatbot';
 import Chatting from '@/pages/chatbot/components/ChattingBubble';
 import ChattingInput from '@/pages/chatbot/components/ChattingInput';
+import ChattingLoading from '@/pages/chatbot/components/ChattingLoading'
 
 const chatPageStyle = cva(
   'relative w-full h-dvh overflow-hidden bg-white flex flex-col',
@@ -28,6 +29,7 @@ type Message = {
 
 export default function ChatPage() {
   const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
   const { messages, addMessage, mutateAsync: sendChat, sessionId } = useChatbot();
   const formatAnswer = (text: string) => {
@@ -56,9 +58,13 @@ export default function ChatPage() {
       timestamp: Date.now(),
     });
 
+    setIsLoading(true);
+
     try {
       const answer = await sendChat({ message: text });
       const formatted = formatAnswer(answer);
+
+      setIsLoading(false); 
 
       addMessage({
         role: 'assistant',
@@ -115,6 +121,12 @@ export default function ChatPage() {
             variant={m.role === 'user' ? 'sent' : 'received'}
           />
         ))}
+
+        {isLoading && (
+  <div className="flex items-start">
+     <ChattingLoading />
+  </div>
+)}
 
         {/* 스크롤 */}
         <div ref={bottomRef} aria-hidden='true' />

--- a/src/pages/events/[id].tsx
+++ b/src/pages/events/[id].tsx
@@ -98,6 +98,7 @@ const EventDetailPage = () => {
             size='large'
             imageSrc={imageUrl ?? ''}
             liked={eventDetail.isBookmarked ?? false}
+            hideLike={true}  
           />
           {/* 관련 행사 */}
           <div

--- a/src/pages/events/[id].tsx
+++ b/src/pages/events/[id].tsx
@@ -10,9 +10,6 @@ import { useEventDetail } from '@/shared/hooks/events/useEventDetail';
 import { buildNextEventList } from '@/shared/utils/buildNextEventList';
 import type { RelatedEventOrEmpty } from '@/shared/types/eventtypes';
 
-const isEmptyItem = (item: RelatedEventOrEmpty): item is { isEmpty: true } =>
-  'isEmpty' in item;
-
 const EventDetailPage = () => {
   const router = useRouter();
   const { id, date } = router.query;
@@ -101,42 +98,45 @@ const EventDetailPage = () => {
             hideLike={true}  
           />
           {/* 관련 행사 */}
-          <div
-            aria-label='관련 행사 목록'
-            className={cn(
-              'grid grid-cols-2 gap-[1.2rem] justify-items-center w-full max-w-[35.4rem]',
-            )}
-          >
-            {nextList.map((item: RelatedEventOrEmpty, idx) => (
-              <div key={idx} className={cn('w-[17rem]')}>
-                {isEmptyItem(item) ? (
+          {nextEvents && nextEvents.length > 0 && (
+            <div
+              aria-label="관련 행사 목록"
+              className={cn(
+                nextEvents.length === 1
+                  ? 'grid grid-cols-1 w-full max-w-[35.4rem]'
+                  : 'grid grid-cols-2 gap-[1.2rem] justify-items-center w-full max-w-[35.4rem] mt-[1.2rem]'
+              )}
+            >
+              {nextEvents.length === 1 ? (
+                <EventCard
+                  eventId={nextEvents[0].eventId}
+                  name={nextEvents[0].title}
+                  address=""
+                  description=""
+                  imageSrc={nextEvents[0].imageUrl}
+                  variant="gray"
+                  size="small"
+                  liked={false}
+                  onClick={() => router.push(`/events/${nextEvents[0].eventId}`)}
+                />
+              ) : (
+                nextEvents.map((item) => (
                   <EventCard
-                    eventId={0}
-                    name='행사 없음'
-                    address=''
-                    description=''
-                    imageSrc=''
-                    variant='gray'
-                    size='small'
-                    liked={false}
-                    onClick={() => null}
-                  />
-                ) : (
-                  <EventCard
+                    key={item.eventId}
                     eventId={item.eventId}
                     name={item.title}
-                    address=''
-                    description=''
+                    address=""
+                    description=""
                     imageSrc={item.imageUrl}
-                    variant='gray'
-                    size='small'
+                    variant="gray"
+                    size="small"
                     liked={false}
                     onClick={() => router.push(`/events/${item.eventId}`)}
                   />
-                )}
-              </div>
-            ))}
-          </div>
+                ))
+              )}
+            </div>
+          )}
         </div>
       </main>
     </div>

--- a/src/pages/mypage/events/[id].tsx
+++ b/src/pages/mypage/events/[id].tsx
@@ -14,7 +14,7 @@ const EventSavePage = () => {
   const { data: eventDetail, isLoading, isError } = useEventDetail(eventId);
 
   useEffect(() => {
-    if (!isLoading && (!isLoading|| !eventDetail)) {
+    if (!isLoading && (isError || !eventDetail)) {
       router.replace('/mypage');
     }
   }, [isLoading, isError, eventDetail, router]);
@@ -57,7 +57,7 @@ const EventSavePage = () => {
               src={imageUrl}
               alt={`${title} 이미지`}
               fill
-              sizes="(max-width: 35.4rem) 100vw, 35.4rem"  
+              sizes='(max-width: 35.4rem) 100vw, 35.4rem'
               className='object-cover rounded-[2rem]'
             />
           ) : (

--- a/src/shared/components/container/EventCard.tsx
+++ b/src/shared/components/container/EventCard.tsx
@@ -18,6 +18,7 @@ interface EventCardProps {
   imageSrc?: string;
   liked?: boolean;
   onClick?: () => void;
+  hideLike?: boolean;
 }
 
 const EventCard = ({
@@ -30,6 +31,7 @@ const EventCard = ({
   imageSrc = '',
   liked = false,
   onClick,
+  hideLike = false,
 }: EventCardProps) => {
   const { isBookmarked, toggleBookmark, requireLogin, setRequireLogin } =
     useBookmark(eventId, liked);
@@ -102,26 +104,28 @@ const EventCard = ({
                 {name}
               </span>
 
-              <button
-                className='cursor-pointer p-1'
-                onClick={(e) => {
-                  e.stopPropagation();
-                  toggleBookmark();
-                }}
-              >
-                <Icon
-                  name='HeartStraight'
-                  size={20}
-                  color={
-                    isBookmarked
-                      ? 'red-400'
-                      : variant === 'mint'
-                      ? 'mint-400'
-                      : 'gray-300'
-                  }
-                  fillColor={isBookmarked ? 'red-300' : undefined}
-                />
-              </button>
+              {!hideLike && (
+                <button
+                  className='cursor-pointer p-1'
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleBookmark();
+                  }}
+                >
+                  <Icon
+                    name='HeartStraight'
+                    size={20}
+                    color={
+                      isBookmarked
+                        ? 'red-400'
+                        : variant === 'mint'
+                        ? 'mint-400'
+                        : 'gray-300'
+                    }
+                    fillColor={isBookmarked ? 'red-300' : undefined}
+                  />
+                </button>
+              )}
             </div>
             {/* 행사 설명 */}
             <div
@@ -148,26 +152,28 @@ const EventCard = ({
                   {name}
                 </span>
 
-                <button
-                  className='cursor-pointer p-1'
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    toggleBookmark();
-                  }}
-                >
-                  <Icon
-                    name='HeartStraight'
-                    size={20}
-                    color={
-                      isBookmarked
-                        ? 'red-400'
-                        : variant === 'mint'
-                        ? 'mint-400'
-                        : 'gray-300'
-                    }
-                    fillColor={isBookmarked ? 'red-300' : undefined}
-                  />
-                </button>
+                {!hideLike && (
+  <button
+    className='cursor-pointer p-1'
+    onClick={(e) => {
+      e.stopPropagation();
+      toggleBookmark();
+    }}
+  >
+    <Icon
+      name='HeartStraight'
+      size={20}
+      color={
+        isBookmarked
+          ? 'red-400'
+          : variant === 'mint'
+          ? 'mint-400'
+          : 'gray-300'
+      }
+      fillColor={isBookmarked ? 'red-300' : undefined}
+    />
+  </button>
+)}
               </div>
               {/* 행사 설명 */}
               <p

--- a/src/shared/components/container/EventCard.tsx
+++ b/src/shared/components/container/EventCard.tsx
@@ -49,7 +49,7 @@ const EventCard = ({
         onClick={onClick}
       >
         {size === 'small' ? (
-          <div className='flex w-[17rem] h-[8rem] p-[0.9rem_1rem] justify-center items-center flex-shrink-0 gap-[2rem]'>
+          <div className='flex w-full h-[8rem] p-[0.9rem_1rem] justify-start items-center flex-shrink-0 gap-[2rem]'>
             {/* 행사 사진 */}
             <div className='relative w-[7rem] h-full rounded-[0.8rem] flex-shrink-0 overflow-hidden'>
               {imageSrc ? (
@@ -153,27 +153,27 @@ const EventCard = ({
                 </span>
 
                 {!hideLike && (
-  <button
-    className='cursor-pointer p-1'
-    onClick={(e) => {
-      e.stopPropagation();
-      toggleBookmark();
-    }}
-  >
-    <Icon
-      name='HeartStraight'
-      size={20}
-      color={
-        isBookmarked
-          ? 'red-400'
-          : variant === 'mint'
-          ? 'mint-400'
-          : 'gray-300'
-      }
-      fillColor={isBookmarked ? 'red-300' : undefined}
-    />
-  </button>
-)}
+                  <button
+                    className='cursor-pointer p-1'
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleBookmark();
+                    }}
+                  >
+                    <Icon
+                      name='HeartStraight'
+                      size={20}
+                      color={
+                        isBookmarked
+                          ? 'red-400'
+                          : variant === 'mint'
+                          ? 'mint-400'
+                          : 'gray-300'
+                      }
+                      fillColor={isBookmarked ? 'red-300' : undefined}
+                    />
+                  </button>
+                )}
               </div>
               {/* 행사 설명 */}
               <p

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -250,5 +250,35 @@ html, body {
 
 .flip-card-back {
   transform: rotateY(180deg);
-
 }
+
+@keyframes dotJump1 {
+  0%   { transform: translateY(0); opacity: 0.5; }
+  50%  { transform: translateY(-0.35rem); opacity: 1; }
+  100% { transform: translateY(0); opacity: 0.5; }
+}
+
+@keyframes dotJump2 {
+  0%   { transform: translateY(0); opacity: 0.5; }
+  50%  { transform: translateY(-0.35rem); opacity: 1; }
+  100% { transform: translateY(0); opacity: 0.5; }
+}
+
+@keyframes dotJump3 {
+  0%   { transform: translateY(0); opacity: 0.5; }
+  50%  { transform: translateY(-0.35rem); opacity: 1; }
+  100% { transform: translateY(0); opacity: 0.5; }
+}
+
+.animate-dot1 {
+  animation: dotJump1 0.7s infinite ease-in-out;
+}
+.animate-dot2 {
+  animation: dotJump2 0.7s infinite ease-in-out;
+  animation-delay: 0.15s;
+}
+.animate-dot3 {
+  animation: dotJump3 0.7s infinite ease-in-out;
+  animation-delay: 0.3s;
+}
+


### PR DESCRIPTION
### 🔥 작업 내용
- 채팅 로딩 추가
- 북마크 상세 이벤트 페이지내에서만 삭제


### 🔗 이슈
- close #https://github.com/geulDa/FE/issues/132

### PR Point (To Reviewer)
## 채팅
답변 받아오는 동안 로딩 애니메이션 추가 해놨습니다(이뻐요)
그리고 전송 버튼도 핑크로 바꿨습니다. 

## 북마크 상세
도저히 연동이 오류 나서 이벤트 - 상세 페이지에서만 북마크 없앴습니다.
나머지 이벤트 페이지 / 마이페이지 / 마이페이지 이벤트 상세에선 다 됩니다.

## 이벤트 페이지 관련 행사
1개뜨면 밑에 1개만 뜨도록 했고 2개 다 없는 경우에는 아예 안뜨게 했습니다.
이게 더 깔끔하고 이쁠거 같아서요


### 📸 스크린샷

## 채팅 로딩

https://github.com/user-attachments/assets/227e4671-50db-45e0-8061-58d9684bac91

<img width="772" height="1328" alt="image" src="https://github.com/user-attachments/assets/e365702f-3cce-477d-8fc4-7582c6048344" />



## 이벤트 페이지 & 이벤트 상세
<img width="684" height="1226" alt="image" src="https://github.com/user-attachments/assets/ccf55511-e91b-4144-a0d5-949dc3531afb" />
<img width="645" height="1232" alt="image" src="https://github.com/user-attachments/assets/98c390e6-95c4-4ecd-803e-c3375f01a2d7" />
<img width="613" height="1252" alt="image" src="https://github.com/user-attachments/assets/85293d66-f292-4e59-8b04-61044a2ad967" />


## 마이페이지 & 마이페이지 상세
<img width="649" height="1223" alt="image" src="https://github.com/user-attachments/assets/30483150-cc64-40bc-b525-ccf25cb04b7d" />

<img width="657" height="1247" alt="image" src="https://github.com/user-attachments/assets/e1e675e4-b511-41d0-8134-157207ff70ae" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 챗봇 메시지 송신 시 로딩 애니메이션 추가
  * 관련 이벤트 표시 방식 개선

* **스타일**
  * 전송 버튼 색상 업데이트

* **버그 수정**
  * 이벤트 페이지 오류 리다이렉트 로직 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->