### PR TITLE
Fix: data-fetch 데이터 리패치

### DIFF
--- a/src/shared/components/main/components/board/Boardgame.tsx
+++ b/src/shared/components/main/components/board/Boardgame.tsx
@@ -10,7 +10,7 @@ const Boardgame = () => {
   const router = useRouter();
   const { data, isLoading, isError } = useGetHasBoardStamp();
 
-  const places = data?.result?.places ?? [];
+  const places = data?.data?.places ?? [];
   console.log('보드게임 스탬프 현황:', places);
 
   if (isLoading) return <p className='text-center mt-10'>로딩 중...</p>;
@@ -39,7 +39,7 @@ const Boardgame = () => {
             if (!cell.active)
               return <div key={key} className='aspect-square bg-transparent' />;
 
-            const matched = places.find((p) => p.placeId === cell.placeId);
+            const matched = places.find((p) => Number(p.placeId) === Number(cell.placeId));
             const name = matched?.name ?? cell.name;
             const hasStamp = matched?.hasStamp ?? false;
 

--- a/src/shared/main/api/getHasBoardStamp.ts
+++ b/src/shared/main/api/getHasBoardStamp.ts
@@ -1,4 +1,4 @@
-import { apiAuth } from '@/shared/api/instance';
+import { apiWithToken } from '@/shared/api/instance';
 
 export interface Place {
   placeId: number;
@@ -10,12 +10,12 @@ export interface StampStatusResponse {
   isSuccess: boolean;
   code: string;
   message: string;
-  result: {
+  data: {
     places: Place[];
   };
 }
 
 export const getHasBoardStamp = async (): Promise<StampStatusResponse> => {
-  const { data } = await apiAuth.get<StampStatusResponse>('/api/places');
+  const { data } = await apiWithToken.get<StampStatusResponse>('/api/places');
   return data;
 };

--- a/src/shared/main/api/getPlaceDetail.ts
+++ b/src/shared/main/api/getPlaceDetail.ts
@@ -1,4 +1,4 @@
-import { apiAuth } from '@/shared/api/instance';
+import { apiWithToken } from '@/shared/api/instance';
 import type { ApiResponse } from '@/shared/types/authtypes';
 
 interface PlaceDetailResponse {
@@ -11,7 +11,7 @@ interface PlaceDetailResponse {
 }
 
 export const getPlaceDetail = async (placeId: number) => {
-  const { data } = await apiAuth.get<ApiResponse<PlaceDetailResponse>>(
+  const { data } = await apiWithToken.get<ApiResponse<PlaceDetailResponse>>(
     `/api/places/${placeId}`,
   );
   return data;


### PR DESCRIPTION
### 🔥 작업 내용
- **API 응답 구조(result → data) 불일치 수정**
  - 서버 응답: `data.places`
  - 프론트 코드: `result.places`
  - 구조 mismatch로 인해 스탬프(hasStamp)가 표시되지 않는 문제 발생
  - `const places = data?.data?.places ?? [];` 로 수정하여 정상 동작 확인

### 🤔 추후 작업 사항
- 스탬프 UI 애니메이션 적용 검토
- 보드게임 전체 레이아웃 리팩토링 예정

### 🔗 이슈
- close #이슈번호

### PR Point (To Reviewer)
- 응답 필드 수정 이후 보드게임 스탬프 표시가 정상적으로 되는지 확인 부탁드립니다.
- `placeId` 매칭 시 유효하지 않은 데이터가 없는지 검토 요청드립니다.

### 📸 피그마 스크린샷 or 기능 GIF
(작업 내역 스크린샷 첨부)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 장소 ID 타입 호환성을 개선하여 데이터 매칭 안정성 강화

* **리팩토링**
  * API 요청 처리 및 데이터 구조 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->